### PR TITLE
made change to validator in booking model, spelling mistake

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,6 +1,6 @@
 class Booking < ApplicationRecord
   belongs_to :user
   belongs_to :cabin
-  validates :start_date, prescence: true
-  validates :end_date, prescence: true
+  validates :start_date, presence: true
+  validates :end_date, presence: true
 end


### PR DESCRIPTION
There was a spelling mistake on the validator for the booking model, it was spelled prescence, made the change to presence.